### PR TITLE
Fix URI parsing

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -147,7 +147,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     //    which will lower-case it (and thus invalidate the address).
     if(uri.startsWith("clam://"))
     {
-        uri.replace(0, 12, "clam:");
+        uri.replace(0, 7, "clam:");
     }
     QUrl uriInstance(uri);
     return parseBitcoinURI(uriInstance, out);


### PR DESCRIPTION
Replace the correct number of characters in URIs starting with "clam://" to result in URIs starting with "clam:".

(The value was 12 because it was unchanged from "blackcoin://".)